### PR TITLE
Add section on privacy

### DIFF
--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -202,6 +202,22 @@ A problem with such recommendations is that they need to be followed
 by implementations that are using dereferenceable identifiers, which
 might not care much.
 
+Privacy considerations
+======================
+
+Dereferencing an identifier leaves a wide-spread data trail,
+ranging from host name lookups visible on the network
+to the absolute URI
+(i.e., the URI without its fragment identifier)
+visible to the operator of the identifier.
+Moreover, the operator might gain additional data about the requester,
+e.g. from a User-Agent header.
+
+By minting single-use dereferencable identifiers
+and assigning short cache lifetimes to the dereferenced resource,
+the originator of a document can track dereferencing clients
+whenever they processes the document the identifier has been created for.
+
 --- back
 
 Acknowledgements


### PR DESCRIPTION
The document doesn't cover the privacy aspect yet at all; I consider that aspect the most important reason why identifier consumers shouldn't even get any ideas about dereferencing identifiers.