### PR TITLE
More pitfalls, more privacy, continuum

### DIFF
--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -98,7 +98,7 @@ Operator:
   dereferenceable identifier.
 
 Consumer:
-: An entity that receives data containing a dereferencable identifier.
+: An entity that receives data containing a dereferenceable identifier.
 
 Directed:
 : A directed identifier is an identifier that has been specifically
@@ -267,7 +267,7 @@ Privacy implications, in particular around single-use identifiers, are discussed
 Usage patterns between dereferencing and precise matching
 =========================================================
 
-Consumers do not face a binary choice between dereferencing dereferencable identifiers and treating them as opaque.
+Consumers do not face a binary choice between dereferencing dereferenceable identifiers and treating them as opaque.
 The space between those extremes is continuous.
 Notable steps consumers can take to mitigate pitfalls of dereferencing are:
 
@@ -292,8 +292,8 @@ Notable steps consumers can take to mitigate pitfalls of dereferencing are:
    In its extreme form, the consumer may not even be equipped to dereference any identifiers
    outside of its cache,
    and the dereferenced representation may already be part of the firmware in ingested form to save runtime resources.
-   Such a consumer shares its properties with a consumer that treats dereferencable identifiers as opaque.
-   However, the authors of the firmware can make good use of the dereferencable identifiers.
+   Such a consumer shares its properties with a consumer that treats dereferenceable identifiers as opaque.
+   However, the authors of the firmware can make good use of the dereferenceable identifiers.
    For example, they can dereference a known (or spidered) set of identifiers in an automated fashion,
    with any suitable amount of caching or manual verification.
 
@@ -326,7 +326,7 @@ visible to the operator of the identifier.
 Moreover, the operator might gain additional data about the requester,
 e.g. from a User-Agent header.
 
-By minting directed (e.g., single-use) dereferencable identifiers
+By minting directed (e.g., single-use) dereferenceable identifiers
 and assigning short cache lifetimes to the dereferenced resource,
 the originator of a document can track dereferencing clients
 whenever they process the document the identifier has been created for.

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -257,6 +257,39 @@ Dereferencing an identifier may involve following some redirections;
 whether that following is actually implied, or desired (or even
 desirable) is rarely being discussed.
 
+Usage patterns between dereferencing and precise matching
+=========================================================
+
+Consumers do not face a binary choice between dereferencing dereferencable identifiers and treating them as opaque.
+The space between those extremes is continuous.
+Some points on that way are these:
+
+* Consumers that dereference may apply caching,
+  which reduces server load and bridges both outages and misconfigurations on the server side.
+
+  These caches may adhere to the caching rules of the underlying systems
+  (DNS result life times, HTTP's freshness rules),
+  but may also exceed them if the alternative are failures or treating the identifier as opaque.
+
+* Consumers may use caching proxy services provided by trusted parties.
+
+  While this increases the susceptibility to service outages,
+  it immediately mitigates the privacy implications of having the consumer's network address visible to the operator.
+  Restrictive policies at the proxy can further mitigate other issues.
+  For example, if the proxy's cache is eagerly populated by web spider operations from public starting points
+  and only ever serves cached results to consumers,
+  it defends against single-use URIs.
+
+* Consumer caches may be pre-populated as part of their firmware update mechanisms.
+
+  In its extreme form, the consumer may not even be equipped to dereference any identifiers
+  outside of its cache,
+  and the dereferenced representation may already be part of the firmware in ingested form.
+  Such a consumer shares its properties with a consumer that treats dereferencable identifiers as opaque.
+  However, the authors of the firmware can make good use of the dereferencable identifiers.
+  For example, they can dereference a known (or spidered) set of identifiers in an automated fashion,
+  with any suitable amount of caching or manual verification.
+
 IANA Considerations
 ==================
 

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -262,7 +262,7 @@ Other pitfalls
 --------------
 
 Denial of service attacks are discussed in {{seccons}}.
-Privacy implications, in particular around single-use identifiers, are discussed in {{privcons}}
+Privacy implications, in particular around single-use identifiers, are discussed in {{privcons}}.
 
 Usage patterns between dereferencing and precise matching
 =========================================================

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -41,7 +41,8 @@ informative:
   COOL:
     title: Cool URIs for the Semantic Web
     author:
-      name: Leo Sauermann, Richard Cyganiak
+      - name: Leo Sauermann
+      - name: Richard Cyganiak
     target: https://www.w3.org/TR/cooluris/
     date: 2008-12-03
 

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -257,6 +257,12 @@ Dereferencing an identifier may involve following some redirections;
 whether that following is actually implied, or desired (or even
 desirable) is rarely being discussed.
 
+Other pitfalls
+--------------
+
+Denial of service attacks are discussed in {{seccons}}.
+Privacy implications, in particular around single-use identifiers, are discussed in {{privcons}}
+
 Usage patterns between dereferencing and precise matching
 =========================================================
 
@@ -297,7 +303,7 @@ This document makes no concrete requests on IANA, but does point out
 that IANA resources might be a good target for a certain class of
 dereferenceable identifiers.
 
-Security considerations
+Security considerations {#seccons}
 =======================
 
 The ability to create a denial of service attack by pointing a
@@ -308,7 +314,7 @@ A problem with such recommendations is that they need to be followed
 by implementations that are using dereferenceable identifiers, which
 might not care much.
 
-Privacy considerations
+Privacy considerations {#privcons}
 ======================
 
 Dereferencing an identifier leaves a wide-spread data trail,

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -38,6 +38,12 @@ informative:
     target: https://html.spec.whatwg.org
     author:
       org: WHATWG
+  COOL:
+    title: Cool URIs for the Semantic Web
+    author:
+      name: Leo Sauermann, Richard Cyganiak
+    target: https://www.w3.org/TR/cooluris/
+    date: 2008-12-03
 
 ...
 
@@ -89,6 +95,9 @@ Operator:
   infrastructure, including the name spaces in use (e.g., DNS names,
   URI paths on a server) are called the operator(s) of the
   dereferenceable identifier.
+
+Consumer:
+: An entity that receives data containing a dereferencable identifier.
 
 Directed:
 : A directed identifier is an identifier that has been specifically
@@ -221,6 +230,25 @@ non-dereferenceable identifier based on this kind of URI namespace)
 than that certain content needs to be offered there (potentially
 presenting non-trivial loads, some mechanisms needed to update that
 information, and legal liabilities that are hard to assess).
+
+Breakage due to incompatible changes
+------------------------------------
+
+Dereferencing an identifier may produce different representations over time.
+While these changes may be intentional and beneficial
+(e.g. because terms are compatibly added to a resource describing terms that are evolved together {{COOL}}),
+they can also cause breakage in applications
+that previously dereferenced the identifier successfully:
+
+* There can be errors in the representation introduced by the change.
+* The operator and the consumer may disagree about what constitutes a compatible change.
+* An updated representation may exceed the consumer's capabilities,
+  e.g. not fitting in an allocated buffer.
+* Even without intended changes to the representation,
+  changes to the channel may exclude certain consumers.
+  For example, the operator's web server may cease to accept the cipher suites implemented in the consumer.
+* When the operator's services are compromised,
+  there may be malicious changes in the representation.
 
 Redirect ambiguities
 --------------------

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -291,7 +291,7 @@ Some points on that way are these:
 
    In its extreme form, the consumer may not even be equipped to dereference any identifiers
    outside of its cache,
-   and the dereferenced representation may already be part of the firmware in ingested form.
+   and the dereferenced representation may already be part of the firmware in ingested form to save runtime resources.
    Such a consumer shares its properties with a consumer that treats dereferencable identifiers as opaque.
    However, the authors of the firmware can make good use of the dereferencable identifiers.
    For example, they can dereference a known (or spidered) set of identifiers in an automated fashion,

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -271,31 +271,31 @@ Consumers do not face a binary choice between dereferencing dereferencable ident
 The space between those extremes is continuous.
 Some points on that way are these:
 
-* Consumers that dereference may apply caching,
-  which reduces server load and bridges both outages and misconfigurations on the server side.
+1. Consumers that dereference may apply caching,
+   which reduces server load and bridges both outages and misconfigurations on the server side.
 
-  These caches may adhere to the caching rules of the underlying systems
-  (DNS result life times, HTTP's freshness rules),
-  but may also stretch them if the alternative are failures or treating the identifier as opaque.
+   These caches may adhere to the caching rules of the underlying systems
+   (DNS result life times, HTTP's freshness rules),
+   but may also stretch them if the alternative are failures or treating the identifier as opaque.
 
-* Consumers may use caching proxy services provided by trusted parties.
+2. Consumers may use caching proxy services provided by trusted parties.
 
-  While this increases the susceptibility to service outages,
-  it immediately mitigates the privacy implications of having the consumer's network address visible to the operator.
-  Restrictive policies at the proxy can further mitigate other issues.
-  For example, if the proxy's cache is eagerly populated by web spider operations from public starting points
-  and only ever serves cached results to consumers,
-  it defends against single-use URIs.
+   While this increases the susceptibility to service outages,
+   it immediately mitigates the privacy implications of having the consumer's network address visible to the operator.
+   Restrictive policies at the proxy can further mitigate other issues.
+   For example, if the proxy's cache is eagerly populated by web spider operations from public starting points
+   and only ever serves cached results to consumers,
+   it defends against single-use URIs.
 
-* Consumer caches may be pre-populated as part of their firmware update mechanisms.
+3. Consumer caches may be pre-populated as part of their firmware update mechanisms.
 
-  In its extreme form, the consumer may not even be equipped to dereference any identifiers
-  outside of its cache,
-  and the dereferenced representation may already be part of the firmware in ingested form.
-  Such a consumer shares its properties with a consumer that treats dereferencable identifiers as opaque.
-  However, the authors of the firmware can make good use of the dereferencable identifiers.
-  For example, they can dereference a known (or spidered) set of identifiers in an automated fashion,
-  with any suitable amount of caching or manual verification.
+   In its extreme form, the consumer may not even be equipped to dereference any identifiers
+   outside of its cache,
+   and the dereferenced representation may already be part of the firmware in ingested form.
+   Such a consumer shares its properties with a consumer that treats dereferencable identifiers as opaque.
+   However, the authors of the firmware can make good use of the dereferencable identifiers.
+   For example, they can dereference a known (or spidered) set of identifiers in an automated fashion,
+   with any suitable amount of caching or manual verification.
 
 IANA Considerations
 ==================

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -269,7 +269,7 @@ Usage patterns between dereferencing and precise matching
 
 Consumers do not face a binary choice between dereferencing dereferencable identifiers and treating them as opaque.
 The space between those extremes is continuous.
-Some points on that way are these:
+Notable steps consumers can take to mitigate pitfalls of dereferencing are:
 
 1. Consumers that dereference may apply caching,
    which reduces server load and bridges both outages and misconfigurations on the server side.

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -323,6 +323,8 @@ By minting directed (e.g., single-use) dereferencable identifiers
 and assigning short cache lifetimes to the dereferenced resource,
 the originator of a document can track dereferencing clients
 whenever they process the document the identifier has been created for.
+Moreover, single-use identifiers can also be used to exfiltrate data
+from originators whose network access is restricted through dereferencing clients.
 
 --- back
 

--- a/draft-bormann-t2trg-deref-id.md
+++ b/draft-bormann-t2trg-deref-id.md
@@ -276,7 +276,7 @@ Some points on that way are these:
 
   These caches may adhere to the caching rules of the underlying systems
   (DNS result life times, HTTP's freshness rules),
-  but may also exceed them if the alternative are failures or treating the identifier as opaque.
+  but may also stretch them if the alternative are failures or treating the identifier as opaque.
 
 * Consumers may use caching proxy services provided by trusted parties.
 


### PR DESCRIPTION
This adds a section on how the continuous space between dereferencing and opaque identifiers enabled by dereferencable identifiers, text around the pitfalls (what can go wrong when things do change, and forward referencing seccons/privcons for smoother reading given the new section would otherwise reach ahead), and adds a privacy note on data exfiltration.

Closes: https://github.com/cabo/deref-id/issues/2

The branch name is a bit of a misnomer; originally I thought the text would more focus on advantages of dereferencable identifiers (that you can extend vocabularies behind them), but looking at the general tone of the document, it seems a bit like we're not so much advertising why deref-ids are good (because making use of that will trigger the pitfalls), but why they're not bad, and how they allow each user to deref as much as works for their use case.